### PR TITLE
Translation for Rotor IV

### DIFF
--- a/translator_I.vhd
+++ b/translator_I.vhd
@@ -1,0 +1,18 @@
+------------------------------ENIGMA-------------------------------------
+-- Arquivo   : translator_I.vhd
+-- Projeto   : Enigma
+---------------------------------------------------------------------------
+-- Descricao :  Traducao do teclado:
+-- =========================================================================
+--							ABCDEFGHIJKLMNOPQRSTUVWXYZ
+--							EKMFLGDQVZNTOWYHXUSPAIBRCJ
+-- ========================================================================
+--							por combinar as letras de entrada.
+----------------------------------------------------------------------------
+-- Revisoes  :
+--     Data        Versao  Autor             						Descricao
+--     23/11/2022  1.0     Sergio Magalhaes Contente 		criacao
+------
+
+
+

--- a/translator_I.vhd
+++ b/translator_I.vhd
@@ -14,5 +14,26 @@
 --     23/11/2022  1.0     Sergio Magalhaes Contente 		criacao
 ------
 
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
 
+entity translator_I is
+    port (
+        original : in  std_logic_vector(4 downto 0); -- Letra do comeco 
+				direction : in std_logic;
+        saida    : out std_logic_vector(4 downto 0) -- Combinacao
+    ); 
+end entity;
 
+architecture translator_I_arch of translator_I is
+	signal s_letter_in, s_letter_out: std_logic_vector(4 downto 0);
+begin
+	s_letter_in <= original;
+	rotation_rotor_I: process (s_letter_in, s_letter_out, direction)
+	begin
+			case s_letter_in is 
+	
+			end case;
+	end process;
+end architecture;

--- a/translator_I.vhd
+++ b/translator_I.vhd
@@ -4,8 +4,9 @@
 ---------------------------------------------------------------------------
 -- Descricao :  Traducao do teclado:
 -- =========================================================================
---							ABCDEFGHIJKLMNOPQRSTUVWXYZ
---							EKMFLGDQVZNTOWYHXUSPAIBRCJ
+--							ABCDEFGHIJKLMNOPQRSTUVWXYZ-
+--							EKMFLGDQVZNTOWYHXUSPAIBR-JC
+--
 -- ========================================================================
 --							por combinar as letras de entrada.
 ----------------------------------------------------------------------------
@@ -32,8 +33,172 @@ begin
 	s_letter_in <= original;
 	rotation_rotor_I: process (s_letter_in, s_letter_out, direction)
 	begin
-			case s_letter_in is 
-	
+			case s_letter_in is
+				when "00000" => -- A	
+					if (direction = '0') then
+							 s_letter_out <= "00100"; --  entrando, E (ETW - I)
+					else
+							 s_letter_out <= "10100"; -- saindo, U (I - ETW)
+					end if;
+				when "00001" =>    -- B
+					if (direction = '0') then
+							 s_letter_out <= "01010"; -- entrando, K (ETW - I)
+					else
+							 s_letter_out <= "10110"; -- saindo, W (I - ETW)
+					end if;
+				when "00010" =>    -- C
+					if (direction = '0') then
+							 s_letter_out <= "01100"; -- entrando, M (I - ETW)
+					else
+							 s_letter_out <= "11000"; -- saindo, Y (ETW - I)
+					end if;
+				when "00011" =>    -- D
+					if (direction = '0') then
+							 s_letter_out <= "00101"; -- entrando, F (I - ETW)
+					else
+							 s_letter_out <= "00110"; -- saindo, G (ETW - I)
+					end if;
+				when "00100" =>    -- E
+					if (direction = '0') then
+							 s_letter_out <= "01011"; -- entrando, L (I - ETW)
+					else
+							 s_letter_out <= "00000"; -- saindo, A (ETW - I)
+					end if;
+				when "00101" =>    -- F
+					if (direction = '0') then
+							 s_letter_out <= "00110"; -- rotor 1, G
+					else
+							 s_letter_out <= "00011"; -- rotor 1, D
+					end if;
+				when "00110" =>    -- G
+					if (direction = '0') then
+							 s_letter_out <= "00011"; -- rotor 1, D
+					else
+							 s_letter_out <= "00101"; -- rotor 1, F
+					end if;
+				when "00111" =>    -- H
+					if (direction = '0') then
+							 s_letter_out <= "10000"; -- rotor 1, Q
+					else
+							 s_letter_out <= "01111"; -- rotor 1, P
+					end if;
+				when "01000" =>    -- I
+					if (direction = '0') then
+							 s_letter_out <= "10101"; -- rotor 1, V
+					else
+							 s_letter_out <= "10101"; -- rotor 1, V
+					end if;
+				when "01001" =>    -- J
+					if (direction = '0') then
+							 s_letter_out <= "11001"; -- rotor 1, Z
+					else
+							 s_letter_out <= "11001"; -- rotor 1, Z
+					end if;
+				when "01010" =>    -- K
+					if (direction = '0') then
+							 s_letter_out <= "01101"; -- rotor 1, N
+					else
+							 s_letter_out <= "00001"; -- rotor 1, B
+					end if;
+				when "01011" =>    -- L
+					if (direction = '0') then
+							 s_letter_out <= "10011"; -- rotor 1, T
+					else
+							 s_letter_out <= "00100"; -- rotor 1, E
+					end if;
+				when "01100" =>    -- M
+					if (direction = '0') then
+							 s_letter_out <= "01110"; -- rotor 1, O
+					else
+							 s_letter_out <= "00010"; -- rotor 1, C
+					end if;
+				when "01101" =>    -- N
+					if (direction = '0') then
+							 s_letter_out <= "10110"; -- rotor 1, W 
+					else
+							 s_letter_out <= "01010"; -- rotor 1, K
+					end if;
+				when "01110" =>    -- O
+					if (direction = '0') then
+								 s_letter_out <= "11000"; -- rotor 1, Y
+						else
+								 s_letter_out <= "01100"; -- rotor 1, M
+						end if;
+					when "01111" =>    -- P
+						if (direction = '0') then
+								 s_letter_out <= "00111"; -- rotor 1, H
+						else
+								 s_letter_out <= "10011"; -- rotor 1, T
+						end if;
+					when "10000" =>    -- Q
+						if (direction = '0') then
+								 s_letter_out <= "10111"; -- rotor 1, X 
+						else
+								 s_letter_out <= "00111"; -- rotor 1, H 
+						end if;
+					when "10001" =>    -- R
+						if (direction = '0') then
+								 s_letter_out <= "10100"; -- rotor 1, U
+						else
+								 s_letter_out <= "10111"; -- rotor 1, X
+						end if;
+					when "10010" =>    -- S
+						if (direction = '0') then
+								 s_letter_out <= "10010"; -- rotor 1, S
+						else
+								 s_letter_out <= "10010"; -- rotor 1, S
+						end if;
+					when "10011" =>    -- T
+						if (direction = '0') then
+								 s_letter_out <= "01111"; -- rotor 1, P
+						else
+								 s_letter_out <= "01011"; -- rotor 1, L
+						end if;
+					when "10100" =>    -- U
+						if (direction = '0') then
+								 s_letter_out <= "00000"; -- rotor 1, A
+						else
+								 s_letter_out <= "10001"; -- rotor 1, R
+						end if;
+					when "10101" =>    -- V
+						if (direction = '0') then
+								 s_letter_out <= "01000"; -- rotor 1, I 
+						else
+								 s_letter_out <= "01000"; -- rotor 1, I
+						end if;
+					when "10110" =>    -- W
+						if (direction = '0') then
+								 s_letter_out <= "00001"; -- rotor 1, B
+						else
+								 s_letter_out <= "01101"; -- rotor 1, N
+						end if;
+					when "10111" =>    -- X
+						if (direction = '0') then
+								 s_letter_out <= "10001"; -- rotor 1, R
+						else
+								 s_letter_out <= "10000"; -- rotor 1, Q
+						end if;
+					when "11000" =>    -- Y
+						if (direction = '0') then
+								 s_letter_out <= "11010"; -- rotor 1, " "
+						else
+								 s_letter_out <= "01110"; -- rotor 1, O
+						end if;
+					when "11001" =>    -- Z
+						if (direction = '0') then
+								 s_letter_out <= "01001"; -- rotor 1, J
+						else
+								 s_letter_out <= "01001"; -- rotor 1, J
+						end if;
+					when "11010" =>    -- " "
+						if (direction = '0') then
+								 s_letter_out <= "00010"; -- rotor 1, C
+						else
+								 s_letter_out <= "11000"; -- rotor 1, Y
+						end if;
+					when others =>     -- should never be reached
+						s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
 			end case;
-	end process;
+		end process rotation_rotor_I;
+		saida <= s_letter_out;
 end architecture;

--- a/translator_II.vhd
+++ b/translator_II.vhd
@@ -1,0 +1,204 @@
+------------------------------ENIGMA-------------------------------------
+-- Arquivo   : translator_I.vhd
+-- Projeto   : Enigma
+---------------------------------------------------------------------------
+-- Descricao :  Traducao do teclado:
+-- =========================================================================
+--							ABCDEFGHIJKLMNOPQRSTUVWXYZ-
+--							EKMFLGDQVZNTOWYHXUSPAIBR-JC
+--
+-- ========================================================================
+--							por combinar as letras de entrada.
+----------------------------------------------------------------------------
+-- Revisoes  :
+--     Data        Versao  Autor             						Descricao
+--     23/11/2022  1.0     Sergio Magalhaes Contente 		criacao
+------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity translator_I is
+    port (
+        original : in  std_logic_vector(4 downto 0); -- Letra do comeco 
+				direction : in std_logic;
+        saida    : out std_logic_vector(4 downto 0) -- Combinacao
+    ); 
+end entity;
+
+architecture translator_I_arch of translator_I is
+	signal s_letter_in, s_letter_out: std_logic_vector(4 downto 0);
+begin
+	s_letter_in <= original;
+	rotation_rotor_I: process (s_letter_in, s_letter_out, direction)
+	begin
+			case s_letter_in is
+				when "00000" => -- A	
+					if (direction = '0') then
+							 s_letter_out <= "00100"; --  entrando, E (ETW - I)
+					else
+							 s_letter_out <= "10100"; -- saindo, U (I - ETW)
+					end if;
+				when "00001" =>    -- B
+					if (direction = '0') then
+							 s_letter_out <= "01010"; -- entrando, K (ETW - I)
+					else
+							 s_letter_out <= "10110"; -- saindo, W (I - ETW)
+					end if;
+				when "00010" =>    -- C
+					if (direction = '0') then
+							 s_letter_out <= "01100"; -- entrando, M (I - ETW)
+					else
+							 s_letter_out <= "11000"; -- saindo, Y (ETW - I)
+					end if;
+				when "00011" =>    -- D
+					if (direction = '0') then
+							 s_letter_out <= "00101"; -- entrando, F (I - ETW)
+					else
+							 s_letter_out <= "00110"; -- saindo, G (ETW - I)
+					end if;
+				when "00100" =>    -- E
+					if (direction = '0') then
+							 s_letter_out <= "01011"; -- entrando, L (I - ETW)
+					else
+							 s_letter_out <= "00000"; -- saindo, A (ETW - I)
+					end if;
+				when "00101" =>    -- F
+					if (direction = '0') then
+							 s_letter_out <= "00110"; -- rotor 1, G
+					else
+							 s_letter_out <= "00011"; -- rotor 1, D
+					end if;
+				when "00110" =>    -- G
+					if (direction = '0') then
+							 s_letter_out <= "00011"; -- rotor 1, D
+					else
+							 s_letter_out <= "00101"; -- rotor 1, F
+					end if;
+				when "00111" =>    -- H
+					if (direction = '0') then
+							 s_letter_out <= "10000"; -- rotor 1, Q
+					else
+							 s_letter_out <= "01111"; -- rotor 1, P
+					end if;
+				when "01000" =>    -- I
+					if (direction = '0') then
+							 s_letter_out <= "10101"; -- rotor 1, V
+					else
+							 s_letter_out <= "10101"; -- rotor 1, V
+					end if;
+				when "01001" =>    -- J
+					if (direction = '0') then
+							 s_letter_out <= "11001"; -- rotor 1, Z
+					else
+							 s_letter_out <= "11001"; -- rotor 1, Z
+					end if;
+				when "01010" =>    -- K
+					if (direction = '0') then
+							 s_letter_out <= "01101"; -- rotor 1, N
+					else
+							 s_letter_out <= "00001"; -- rotor 1, B
+					end if;
+				when "01011" =>    -- L
+					if (direction = '0') then
+							 s_letter_out <= "10011"; -- rotor 1, T
+					else
+							 s_letter_out <= "00100"; -- rotor 1, E
+					end if;
+				when "01100" =>    -- M
+					if (direction = '0') then
+							 s_letter_out <= "01110"; -- rotor 1, O
+					else
+							 s_letter_out <= "00010"; -- rotor 1, C
+					end if;
+				when "01101" =>    -- N
+					if (direction = '0') then
+							 s_letter_out <= "10110"; -- rotor 1, W 
+					else
+							 s_letter_out <= "01010"; -- rotor 1, K
+					end if;
+				when "01110" =>    -- O
+					if (direction = '0') then
+								 s_letter_out <= "11000"; -- rotor 1, Y
+						else
+								 s_letter_out <= "01100"; -- rotor 1, M
+						end if;
+					when "01111" =>    -- P
+						if (direction = '0') then
+								 s_letter_out <= "00111"; -- rotor 1, H
+						else
+								 s_letter_out <= "10011"; -- rotor 1, T
+						end if;
+					when "10000" =>    -- Q
+						if (direction = '0') then
+								 s_letter_out <= "10111"; -- rotor 1, X 
+						else
+								 s_letter_out <= "00111"; -- rotor 1, H 
+						end if;
+					when "10001" =>    -- R
+						if (direction = '0') then
+								 s_letter_out <= "10100"; -- rotor 1, U
+						else
+								 s_letter_out <= "10111"; -- rotor 1, X
+						end if;
+					when "10010" =>    -- S
+						if (direction = '0') then
+								 s_letter_out <= "10010"; -- rotor 1, S
+						else
+								 s_letter_out <= "10010"; -- rotor 1, S
+						end if;
+					when "10011" =>    -- T
+						if (direction = '0') then
+								 s_letter_out <= "01111"; -- rotor 1, P
+						else
+								 s_letter_out <= "01011"; -- rotor 1, L
+						end if;
+					when "10100" =>    -- U
+						if (direction = '0') then
+								 s_letter_out <= "00000"; -- rotor 1, A
+						else
+								 s_letter_out <= "10001"; -- rotor 1, R
+						end if;
+					when "10101" =>    -- V
+						if (direction = '0') then
+								 s_letter_out <= "01000"; -- rotor 1, I 
+						else
+								 s_letter_out <= "01000"; -- rotor 1, I
+						end if;
+					when "10110" =>    -- W
+						if (direction = '0') then
+								 s_letter_out <= "00001"; -- rotor 1, B
+						else
+								 s_letter_out <= "01101"; -- rotor 1, N
+						end if;
+					when "10111" =>    -- X
+						if (direction = '0') then
+								 s_letter_out <= "10001"; -- rotor 1, R
+						else
+								 s_letter_out <= "10000"; -- rotor 1, Q
+						end if;
+					when "11000" =>    -- Y
+						if (direction = '0') then
+								 s_letter_out <= "11010"; -- rotor 1, " "
+						else
+								 s_letter_out <= "01110"; -- rotor 1, O
+						end if;
+					when "11001" =>    -- Z
+						if (direction = '0') then
+								 s_letter_out <= "01001"; -- rotor 1, J
+						else
+								 s_letter_out <= "01001"; -- rotor 1, J
+						end if;
+					when "11010" =>    -- " "
+						if (direction = '0') then
+								 s_letter_out <= "00010"; -- rotor 1, C
+						else
+								 s_letter_out <= "11000"; -- rotor 1, Y
+						end if;
+					when others =>     -- should never be reached
+						s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
+			end case;
+		end process rotation_rotor_I;
+		saida <= s_letter_out;
+end architecture;

--- a/translator_II.vhd
+++ b/translator_II.vhd
@@ -1,11 +1,11 @@
 ------------------------------ENIGMA-------------------------------------
--- Arquivo   : translator_I.vhd
+-- Arquivo   : translator_II.vhd
 -- Projeto   : Enigma
 ---------------------------------------------------------------------------
 -- Descricao :  Traducao do teclado:
 -- =========================================================================
 --							ABCDEFGHIJKLMNOPQRSTUVWXYZ-
---							EKMFLGDQVZNTOWYHXUSPAIBR-JC
+--							AJDK-IRUXBLHWTMCQGZNPYFVOES
 --
 -- ========================================================================
 --							por combinar as letras de entrada.
@@ -19,7 +19,7 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity translator_I is
+entity translator_II is
     port (
         original : in  std_logic_vector(4 downto 0); -- Letra do comeco 
 				direction : in std_logic;
@@ -27,7 +27,7 @@ entity translator_I is
     ); 
 end entity;
 
-architecture translator_I_arch of translator_I is
+architecture translator_II_arch of translator_II is
 	signal s_letter_in, s_letter_out: std_logic_vector(4 downto 0);
 begin
 	s_letter_in <= original;
@@ -36,169 +36,169 @@ begin
 			case s_letter_in is
 				when "00000" => -- A	
 					if (direction = '0') then
-							 s_letter_out <= "00100"; --  entrando, E (ETW - I)
+						when "001"  => s_letter_out <= "00000"; -- rotor 2, A
 					else
-							 s_letter_out <= "10100"; -- saindo, U (I - ETW)
+						when "001"  => s_letter_out <= "00000"; -- rotor 2, A
 					end if;
 				when "00001" =>    -- B
 					if (direction = '0') then
-							 s_letter_out <= "01010"; -- entrando, K (ETW - I)
+						when "001"  => s_letter_out <= "01001"; -- rotor 2, J
 					else
-							 s_letter_out <= "10110"; -- saindo, W (I - ETW)
+						when "001"  => s_letter_out <= "01001"; -- rotor 2, J
 					end if;
 				when "00010" =>    -- C
 					if (direction = '0') then
-							 s_letter_out <= "01100"; -- entrando, M (I - ETW)
+						when "001"  => s_letter_out <= "00011"; -- rotor 2, D
 					else
-							 s_letter_out <= "11000"; -- saindo, Y (ETW - I)
+						when "001"  => s_letter_out <= "01111"; -- rotor 2, P
 					end if;
 				when "00011" =>    -- D
 					if (direction = '0') then
-							 s_letter_out <= "00101"; -- entrando, F (I - ETW)
+						when "001"  => s_letter_out <= "01010"; -- rotor 2, K
 					else
-							 s_letter_out <= "00110"; -- saindo, G (ETW - I)
+						when "001"  => s_letter_out <= "00010"; -- rotor 2, C
 					end if;
 				when "00100" =>    -- E
 					if (direction = '0') then
-							 s_letter_out <= "01011"; -- entrando, L (I - ETW)
+						when "001"  => s_letter_out <= "11010"; -- rotor 2, -
 					else
-							 s_letter_out <= "00000"; -- saindo, A (ETW - I)
+						when "001"  => s_letter_out <= "11001"; -- rotor 2, Z
 					end if;
 				when "00101" =>    -- F
 					if (direction = '0') then
-							 s_letter_out <= "00110"; -- rotor 1, G
+						when "001"  => s_letter_out <= "01000"; -- rotor 2, I
 					else
-							 s_letter_out <= "00011"; -- rotor 1, D
+						when "001"  => s_letter_out <= "10110"; -- rotor 2, W
 					end if;
 				when "00110" =>    -- G
 					if (direction = '0') then
-							 s_letter_out <= "00011"; -- rotor 1, D
+						when "001"  => s_letter_out <= "10001"; -- rotor 2, R
 					else
-							 s_letter_out <= "00101"; -- rotor 1, F
+						when "001"  => s_letter_out <= "10001"; -- rotor 2, R
 					end if;
 				when "00111" =>    -- H
 					if (direction = '0') then
-							 s_letter_out <= "10000"; -- rotor 1, Q
+						when "001"  => s_letter_out <= "10100"; -- rotor 2, U
 					else
-							 s_letter_out <= "01111"; -- rotor 1, P
+						when "001"  => s_letter_out <= "01011"; -- rotor 2, L
 					end if;
 				when "01000" =>    -- I
 					if (direction = '0') then
-							 s_letter_out <= "10101"; -- rotor 1, V
+						when "001"  => s_letter_out <= "10111"; -- rotor 2, X
 					else
-							 s_letter_out <= "10101"; -- rotor 1, V
+						when "001"  => s_letter_out <= "00101"; -- rotor 2, F
 					end if;
 				when "01001" =>    -- J
 					if (direction = '0') then
-							 s_letter_out <= "11001"; -- rotor 1, Z
+						when "001"  => s_letter_out <= "00001"; -- rotor 2, B
 					else
-							 s_letter_out <= "11001"; -- rotor 1, Z
+						when "001"  => s_letter_out <= "00001"; -- rotor 2, B
 					end if;
 				when "01010" =>    -- K
 					if (direction = '0') then
-							 s_letter_out <= "01101"; -- rotor 1, N
+						when "001"  => s_letter_out <= "01011"; -- rotor 2, L
 					else
-							 s_letter_out <= "00001"; -- rotor 1, B
+						when "001"  => s_letter_out <= "00011"; -- rotor 2, D
 					end if;
 				when "01011" =>    -- L
 					if (direction = '0') then
-							 s_letter_out <= "10011"; -- rotor 1, T
+						when "001"  => s_letter_out <= "00111"; -- rotor 2, H
 					else
-							 s_letter_out <= "00100"; -- rotor 1, E
+						when "001"  => s_letter_out <= "01010"; -- rotor 2, K
 					end if;
 				when "01100" =>    -- M
 					if (direction = '0') then
-							 s_letter_out <= "01110"; -- rotor 1, O
+						when "001"  => s_letter_out <= "10110"; -- rotor 2, W
 					else
-							 s_letter_out <= "00010"; -- rotor 1, C
+						when "001"  => s_letter_out <= "01110"; -- rotor 2, O
 					end if;
 				when "01101" =>    -- N
 					if (direction = '0') then
-							 s_letter_out <= "10110"; -- rotor 1, W 
+						when "001"  => s_letter_out <= "10011"; -- rotor 2, T
 					else
-							 s_letter_out <= "01010"; -- rotor 1, K
+						when "001"  => s_letter_out <= "10011"; -- rotor 2, T
 					end if;
 				when "01110" =>    -- O
 					if (direction = '0') then
-								 s_letter_out <= "11000"; -- rotor 1, Y
-						else
-								 s_letter_out <= "01100"; -- rotor 1, M
-						end if;
-					when "01111" =>    -- P
-						if (direction = '0') then
-								 s_letter_out <= "00111"; -- rotor 1, H
-						else
-								 s_letter_out <= "10011"; -- rotor 1, T
-						end if;
-					when "10000" =>    -- Q
-						if (direction = '0') then
-								 s_letter_out <= "10111"; -- rotor 1, X 
-						else
-								 s_letter_out <= "00111"; -- rotor 1, H 
-						end if;
-					when "10001" =>    -- R
-						if (direction = '0') then
-								 s_letter_out <= "10100"; -- rotor 1, U
-						else
-								 s_letter_out <= "10111"; -- rotor 1, X
-						end if;
-					when "10010" =>    -- S
-						if (direction = '0') then
-								 s_letter_out <= "10010"; -- rotor 1, S
-						else
-								 s_letter_out <= "10010"; -- rotor 1, S
-						end if;
-					when "10011" =>    -- T
-						if (direction = '0') then
-								 s_letter_out <= "01111"; -- rotor 1, P
-						else
-								 s_letter_out <= "01011"; -- rotor 1, L
-						end if;
-					when "10100" =>    -- U
-						if (direction = '0') then
-								 s_letter_out <= "00000"; -- rotor 1, A
-						else
-								 s_letter_out <= "10001"; -- rotor 1, R
-						end if;
-					when "10101" =>    -- V
-						if (direction = '0') then
-								 s_letter_out <= "01000"; -- rotor 1, I 
-						else
-								 s_letter_out <= "01000"; -- rotor 1, I
-						end if;
-					when "10110" =>    -- W
-						if (direction = '0') then
-								 s_letter_out <= "00001"; -- rotor 1, B
-						else
-								 s_letter_out <= "01101"; -- rotor 1, N
-						end if;
-					when "10111" =>    -- X
-						if (direction = '0') then
-								 s_letter_out <= "10001"; -- rotor 1, R
-						else
-								 s_letter_out <= "10000"; -- rotor 1, Q
-						end if;
-					when "11000" =>    -- Y
-						if (direction = '0') then
-								 s_letter_out <= "11010"; -- rotor 1, " "
-						else
-								 s_letter_out <= "01110"; -- rotor 1, O
-						end if;
-					when "11001" =>    -- Z
-						if (direction = '0') then
-								 s_letter_out <= "01001"; -- rotor 1, J
-						else
-								 s_letter_out <= "01001"; -- rotor 1, J
-						end if;
-					when "11010" =>    -- " "
-						if (direction = '0') then
-								 s_letter_out <= "00010"; -- rotor 1, C
-						else
-								 s_letter_out <= "11000"; -- rotor 1, Y
-						end if;
-					when others =>     -- should never be reached
-						s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
-			end case;
-		end process rotation_rotor_I;
-		saida <= s_letter_out;
+						when "001"  => s_letter_out <= "01100"; -- rotor 2, M
+					else
+						when "001"  => s_letter_out <= "11000"; -- rotor 2, Y
+					end if;
+				when "01111" =>    -- P
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "00010"; -- rotor 2, C
+					else
+						when "001"  => s_letter_out <= "10100"; -- rotor 2, U
+					end if;
+				when "10000" =>    -- Q
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "10000"; -- rotor 2, Q
+					else
+						when "001"  => s_letter_out <= "10000"; -- rotor 2, Q
+					end if;
+				when "10001" =>    -- R
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "00110"; -- rotor 2, G
+					else
+						when "001"  => s_letter_out <= "00110"; -- rotor 2, G
+					end if;
+				when "10010" =>    -- S
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "11001"; -- rotor 2, Z
+					else
+						when "001"  => s_letter_out <= "11010"; -- rotor 2, -
+					end if;
+				when "10011" =>    -- T
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "01101"; -- rotor 2, N
+					else
+						when "001"  => s_letter_out <= "01101"; -- rotor 2, N
+					end if;
+				when "10100" =>    -- U
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "01111"; -- rotor 2, P
+					else
+						when "001"  => s_letter_out <= "00111"; -- rotor 2, H
+					end if;
+				when "10101" =>    -- V
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "11000"; -- rotor 2, Y
+					else
+						when "001"  => s_letter_out <= "10111"; -- rotor 2, X
+					end if;
+				when "10110" =>    -- W
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "00101"; -- rotor 2, F
+					else
+						when "001"  => s_letter_out <= "01100"; -- rotor 2, M
+					end if;
+				when "10111" =>    -- X
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "10101"; -- rotor 2, V
+					else
+						when "001"  => s_letter_out <= "01000"; -- rotor 2, I
+					end if;
+				when "11000" =>    -- Y
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "01110"; -- rotor 2, O
+					else
+						when "001"  => s_letter_out <= "10101"; -- rotor 2, V
+					end if;
+				when "11001" =>    -- Z
+					if (direction = '0') then
+						when "001"  => s_letter_out <= "00100"; -- rotor 2, E
+					else
+						when "001"  => s_letter_out <= "10010"; -- rotor 2, S
+					end if;
+				when "11010" =>    -- " "
+					if (direction = '0') then
+								s_letter_out <= "11001"; -- rotor 1, S
+					else
+								s_letter_out <= "00100"; -- rotor 1, E
+					end if;
+				when others =>     -- should never be reached
+					s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
+		end case;
+	end process rotation_rotor_I;
+	saida <= s_letter_out;
 end architecture;

--- a/translator_III.vhd
+++ b/translator_III.vhd
@@ -1,0 +1,204 @@
+------------------------------ENIGMA-------------------------------------
+-- Arquivo   : translator_III.vhd
+-- Projeto   : Enigma
+---------------------------------------------------------------------------
+-- Descricao :  Traducao do teclado:
+-- =========================================================================
+--							ABCDEFGHIJKLMNOPQRSTUVWXYZ-
+--							BDFHJ-CPRTXVZNYEIWGAKMUSQOL
+--
+-- ========================================================================
+--							por combinar as letras de entrada.
+----------------------------------------------------------------------------
+-- Revisoes  :
+--     Data        Versao  Autor             						Descricao
+--     23/11/2022  1.0     Sergio Magalhaes Contente 		criacao
+------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity translator_IIII is
+    port (
+        original : in  std_logic_vector(4 downto 0); -- Letra do comeco 
+				direction : in std_logic;
+        saida    : out std_logic_vector(4 downto 0) -- Combinacao
+    ); 
+end entity;
+
+architecture translator_II_arch of translator_II is
+	signal s_letter_in, s_letter_out: std_logic_vector(4 downto 0);
+begin
+	s_letter_in <= original;
+	rotation_rotor_III: process (s_letter_in, s_letter_out, direction)
+	begin
+			case s_letter_in is
+				when "00000" => -- A	
+					if (direction = '0') then
+						s_letter_out <= "00001"; -- rotor 3, B
+					else
+						s_letter_out <= "10011"; -- rotor 3, T
+					end if;
+				when "00001" =>    -- B
+					if (direction = '0') then
+						s_letter_out <= "00011"; -- rotor 3, D
+					else
+						s_letter_out <= "00000"; -- rotor 3, A
+					end if;
+				when "00010" =>    -- C
+					if (direction = '0') then
+						s_letter_out <= "00101"; -- rotor 3, F
+					else
+						s_letter_out <= "00110"; -- rotor 3, G
+					end if;
+				when "00011" =>    -- D
+					if (direction = '0') then
+						s_letter_out <= "00111"; -- rotor 3, H
+					else
+						s_letter_out <= "00001"; -- rotor 3, B
+					end if;
+				when "00100" =>    -- E
+					if (direction = '0') then
+						s_letter_out <= "01001"; -- rotor 3, J
+					else
+						s_letter_out <= "01111"; -- rotor 3, P
+					end if;
+				when "00101" =>    -- F
+					if (direction = '0') then
+						s_letter_out <= "11010"; -- rotor 3, " "
+					else
+						s_letter_out <= "00010"; -- rotor 3, C
+					end if;
+				when "00110" =>    -- G
+					if (direction = '0') then
+						s_letter_out <= "00010"; -- rotor 3, C
+					else
+						s_letter_out <= "10010"; -- rotor 3, S
+					end if;
+				when "00111" =>    -- H
+					if (direction = '0') then
+						s_letter_out <= "01111"; -- rotor 3, P
+					else
+						s_letter_out <= "00011"; -- rotor 3, D
+					end if;
+				when "01000" =>    -- I
+					if (direction = '0') then
+						s_letter_out <= "10001"; -- rotor 3, R
+					else
+						s_letter_out <= "10000"; -- rotor 3, Q
+					end if;
+				when "01001" =>    -- J
+					if (direction = '0') then
+						s_letter_out <= "10011"; -- rotor 3, T
+					else
+						s_letter_out <= "00100"; -- rotor 3, E
+					end if;
+				when "01010" =>    -- K
+					if (direction = '0') then
+						s_letter_out <= "10111"; -- rotor 3, X
+					else
+						s_letter_out <= "10100"; -- rotor 3, U
+					end if;
+				when "01011" =>    -- L
+					if (direction = '0') then
+						s_letter_out <= "10101"; -- rotor 3, V
+					else
+						s_letter_out <= "11010"; -- rotor 3, " "
+					end if;
+				when "01100" =>    -- M
+					if (direction = '0') then
+						s_letter_out <= "11001"; -- rotor 3, Z
+					else
+						s_letter_out <= "10101"; -- rotor 3, V
+					end if;
+				when "01101" =>    -- N
+					if (direction = '0') then
+						s_letter_out <= "01101"; -- rotor 3, N
+					else
+						s_letter_out <= "01101"; -- rotor 3, N
+					end if;
+				when "01110" =>    -- O
+					if (direction = '0') then
+						s_letter_out <= "11000"; -- rotor 3, Y
+					else
+						s_letter_out <= "11001"; -- rotor 3, Z
+					end if;
+				when "01111" =>    -- P
+					if (direction = '0') then
+						s_letter_out <= "00100"; -- rotor 3, E
+					else
+						s_letter_out <= "00111"; -- rotor 3, H
+					end if;
+				when "10000" =>    -- Q
+					if (direction = '0') then
+						s_letter_out <= "01000"; -- rotor 3, I
+					else
+						s_letter_out <= "11000"; -- rotor 3, Y
+					end if;
+				when "10001" =>    -- R
+					if (direction = '0') then
+						s_letter_out <= "10110"; -- rotor 3, W
+					else
+						s_letter_out <= "01000"; -- rotor 3, I
+					end if;
+				when "10010" =>    -- S
+					if (direction = '0') then
+						s_letter_out <= "00110"; -- rotor 3, G
+					else
+						s_letter_out <= "10111"; -- rotor 3, X
+					end if;
+				when "10011" =>    -- T
+					if (direction = '0') then
+						s_letter_out <= "00000"; -- rotor 3, A
+					else
+						s_letter_out <= "01001"; -- rotor 3, J
+					end if;
+				when "10100" =>    -- U
+					if (direction = '0') then
+						s_letter_out <= "01010"; -- rotor 3, K
+					else
+						s_letter_out <= "10110"; -- rotor 3, W
+					end if;
+				when "10101" =>    -- V
+					if (direction = '0') then
+						s_letter_out <= "01100"; -- rotor 3, M
+					else
+						s_letter_out <= "01011"; -- rotor 3, L
+					end if;
+				when "10110" =>    -- W
+					if (direction = '0') then
+						s_letter_out <= "10100"; -- rotor 3, U
+					else
+						s_letter_out <= "10001"; -- rotor 3, R
+					end if;
+				when "10111" =>    -- X
+					if (direction = '0') then
+						s_letter_out <= "10010"; -- rotor 3, S
+					else
+					s_letter_out <= "01010"; -- rotor 3, K
+					end if;
+				when "11000" =>    -- Y
+					if (direction = '0') then
+						s_letter_out <= "10000"; -- rotor 3, Q
+					else
+						s_letter_out <= "01110"; -- rotor 3, O
+					end if;
+				when "11001" =>    -- Z
+					if (direction = '0') then
+						s_letter_out <= "01110"; -- rotor 3, O
+					else
+						s_letter_out <= "01100"; -- rotor 3, M
+					end if;
+				when "11010" =>    -- " "
+					if (direction = '0') then
+								s_letter_out <= "01011"; -- rotor 1, L
+					else
+								s_letter_out <= "00101"; -- rotor 1, F
+					end if;
+				when others =>     -- should never be reached
+					s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
+		end case;
+	end process rotation_rotor_III;
+	saida <= s_letter_out;
+end architecture;

--- a/translator_IV.vhd
+++ b/translator_IV.vhd
@@ -1,0 +1,204 @@
+------------------------------ENIGMA-------------------------------------
+-- Arquivo   : translator_IV.vhd
+-- Projeto   : Enigma
+---------------------------------------------------------------------------
+-- Descricao :  Traducao do teclado:
+-- =========================================================================
+--							ABCDEFGHIJKLMNOPQRSTUVWXYZ-
+--							ESOVPZJ-YQUIRHXLNFTGKDCMWBA
+--
+-- ========================================================================
+--							por combinar as letras de entrada.
+----------------------------------------------------------------------------
+-- Revisoes  :
+--     Data        Versao  Autor             						Descricao
+--     23/11/2022  1.0     Sergio Magalhaes Contente 		criacao
+------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity translator_IIII is
+    port (
+        original : in  std_logic_vector(4 downto 0); -- Letra do comeco 
+				direction : in std_logic;
+        saida    : out std_logic_vector(4 downto 0) -- Combinacao
+    ); 
+end entity;
+
+architecture translator_II_arch of translator_II is
+	signal s_letter_in, s_letter_out: std_logic_vector(4 downto 0);
+begin
+	s_letter_in <= original;
+	rotation_rotor_III: process (s_letter_in, s_letter_out, direction)
+	begin
+			case s_letter_in is
+				when "00000" => -- A	
+					if (direction = '0') then
+						s_letter_out <= "00100"; -- rotor 4, E
+					else
+						s_letter_out <= "11010"; -- rotor 4, " "
+					end if;
+				when "00001" =>    -- B
+					if (direction = '0') then
+						s_letter_out <= "10010"; -- rotor 4, S
+					else
+						s_letter_out <= "11001"; -- rotor 4, Z
+					end if;
+				when "00010" =>    -- C
+					if (direction = '0') then
+						s_letter_out <= "01110"; -- rotor 4, O
+					else
+						s_letter_out <= "10110"; -- rotor 4, W
+					end if;
+				when "00011" =>    -- D
+					if (direction = '0') then
+						s_letter_out <= "10101"; -- rotor 4, V
+					else
+						s_letter_out <= "10101"; -- rotor 4, V
+					end if;
+				when "00100" =>    -- E
+					if (direction = '0') then
+						s_letter_out <= "01111"; -- rotor 4, P
+					else
+						s_letter_out <= "00000"; -- rotor 4, A
+					end if;
+				when "00101" =>    -- F
+					if (direction = '0') then
+						s_letter_out <= "11001"; -- rotor 4, Z
+					else
+						s_letter_out <= "10001"; -- rotor 4, R
+					end if;
+				when "00110" =>    -- G
+					if (direction = '0') then
+						s_letter_out <= "01001"; -- rotor 4, J
+					else
+						s_letter_out <= "10011"; -- rotor 4, T
+					end if;
+				when "00111" =>    -- H
+					if (direction = '0') then
+						s_letter_out <= "11010"; -- rotor 4, " "
+					else
+						s_letter_out <= "01101"; -- rotor 4, N
+					end if;
+				when "01000" =>    -- I
+					if (direction = '0') then
+						s_letter_out <= "11000"; -- rotor 4, Y
+					else
+						s_letter_out <= "01011"; -- rotor 4, L
+					end if;
+				when "01001" =>    -- J
+					if (direction = '0') then
+						s_letter_out <= "10000"; -- rotor 4, Q
+					else
+						s_letter_out <= "00110"; -- rotor 4, G
+					end if;
+				when "01010" =>    -- K
+					if (direction = '0') then
+						s_letter_out <= "10100"; -- rotor 4, U
+					else
+						s_letter_out <= "10100"; -- rotor 4, U
+					end if;
+				when "01011" =>    -- L
+					if (direction = '0') then
+						s_letter_out <= "01000"; -- rotor 4, I
+					else
+						s_letter_out <= "01111"; -- rotor 4, P
+					end if;
+				when "01100" =>    -- M
+					if (direction = '0') then
+						s_letter_out <= "10001"; -- rotor 4, R
+					else
+						s_letter_out <= "10111"; -- rotor 4, X
+					end if;
+				when "01101" =>    -- N
+					if (direction = '0') then
+						s_letter_out <= "00111"; -- rotor 4, H
+					else
+						s_letter_out <= "10000"; -- rotor 4, Q
+					end if;
+				when "01110" =>    -- O
+					if (direction = '0') then
+						s_letter_out <= "10111"; -- rotor 4, X
+					else
+						s_letter_out <= "00010"; -- rotor 4, C
+					end if;
+				when "01111" =>    -- P
+					if (direction = '0') then
+						s_letter_out <= "01011"; -- rotor 4, L
+					else
+						s_letter_out <= "00100"; -- rotor 4, E
+					end if;
+				when "10000" =>    -- Q
+					if (direction = '0') then
+						s_letter_out <= "01101"; -- rotor 4, N
+					else
+						s_letter_out <= "01001"; -- rotor 4, J
+					end if;
+				when "10001" =>    -- R
+					if (direction = '0') then
+						s_letter_out <= "00101"; -- rotor 4, F
+					else
+						s_letter_out <= "01100"; -- rotor 4, M
+					end if;
+				when "10010" =>    -- S
+					if (direction = '0') then
+						s_letter_out <= "10011"; -- rotor 4, T
+					else
+						s_letter_out <= "00001"; -- rotor 4, B
+					end if;
+				when "10011" =>    -- T
+					if (direction = '0') then
+						s_letter_out <= "00110"; -- rotor 4, G
+					else
+						s_letter_out <= "10010"; -- rotor 4, S
+					end if;
+				when "10100" =>    -- U
+					if (direction = '0') then
+						s_letter_out <= "01010"; -- rotor 4, K
+					else
+						s_letter_out <= "01010"; -- rotor 4, K
+					end if;
+				when "10101" =>    -- V
+					if (direction = '0') then
+						s_letter_out <= "00011"; -- rotor 4, D
+					else
+						s_letter_out <= "00011"; -- rotor 4, D
+					end if;
+				when "10110" =>    -- W
+					if (direction = '0') then
+						s_letter_out <= "00010"; -- rotor 4, C
+					else
+						s_letter_out <= "11000"; -- rotor 4, Y
+					end if;
+				when "10111" =>    -- X
+					if (direction = '0') then
+						s_letter_out <= "01100"; -- rotor 4, M
+					else
+						s_letter_out <= "01110"; -- rotor 4, O
+					end if;
+				when "11000" =>    -- Y
+					if (direction = '0') then
+						s_letter_out <= "10110"; -- rotor 4, W
+					else
+						s_letter_out <= "01000"; -- rotor 4, I
+					end if;
+				when "11001" =>    -- Z
+					if (direction = '0') then
+						s_letter_out <= "00001"; -- rotor 4, B
+					else
+						s_letter_out <= "00101"; -- rotor 4, F
+					end if;
+				when "11010" =>    -- " "
+					if (direction = '0') then
+								s_letter_out <= "00000"; -- rotor 1, A
+					else
+								s_letter_out <= "00111"; -- rotor 1, H
+					end if;
+				when others =>     -- should never be reached
+					s_letter_out <= (others => '1'); -- non-existing letter code ("11111")
+		end case;
+	end process rotation_rotor_III;
+	saida <= s_letter_out;
+end architecture;


### PR DESCRIPTION
Essa PR tem como intuito fazer o mapeamento das combinações presentes no rotor I, de tal forma a abordar a tradução tanto na direção "0" - do teclado (ETW) para o rotor (II) - quanto na direção "1" - do rotor (II) para o teclado (ETW).

ABCDEFGHIJKLMNOPQRSTUVWXYZ-
EJSOVPZJ-YQUIRHXLNFTGKDCMWBA

"-" significa o caractere de espaço, escolhi arbitrariamente as letras trocadas.